### PR TITLE
Add prop to retrieve braintree dataCollector

### DIFF
--- a/src/api.js
+++ b/src/api.js
@@ -32,6 +32,13 @@ export default class BraintreeClientApi {
                     this.onError(err);
                 } else {
                     this.create(clientInstance, onAuthorizationSuccess);
+
+                    if (this.wrapperHandlers.onDataCollectorInstanceReady) {
+                        Braintree.dataCollector.create({
+                            client: clientInstance,
+                            kount: true,
+                        }, this.wrapperHandlers.onDataCollectorInstanceReady);
+                    }
                 }
             });
         }


### PR DESCRIPTION
I've added a simple callback to receive the `Braintree.dataCollector.create` result.