### PR TITLE
Added some small features

### DIFF
--- a/demo.jsx
+++ b/demo.jsx
@@ -30,7 +30,21 @@ class BraintreeHostedfieldDemo extends React.PureComponent {
     }
 
     onCardTypeChange({ cards }) {
-        this.setState({ card: (1 === cards.length) ? cards[0].type : '' });
+        if (1 === cards.length) {
+          const [{card}] = cards;
+          
+          this.setState({ card: card.type });
+          
+          if (card.code && card.code.name) {
+            this.cvvField.setPlaceholder(card.code.name);
+          } else {
+            this.cvvField.setPlaceholder('CVV');
+          }
+
+        } else {
+          this.setState({ card: '' });
+          this.cvvField.setPlaceholder('CVV');
+        }
     }
 
     state = {
@@ -90,7 +104,7 @@ class BraintreeHostedfieldDemo extends React.PureComponent {
                         Year:
                         <HostedField type="expirationYear" />
                         CVV:
-                        <HostedField type="cvv" />
+                        <HostedField type="cvv" placeholder="CVV" ref={cvvField => { this.cvvField = cvvField; }} />
                         Zip:
                         <HostedField type="postalCode" />
                     </div>

--- a/demo.jsx
+++ b/demo.jsx
@@ -31,7 +31,7 @@ class BraintreeHostedfieldDemo extends React.PureComponent {
 
     onCardTypeChange({ cards }) {
         if (1 === cards.length) {
-          const [{card}] = cards;
+          const [card] = cards;
           
           this.setState({ card: card.type });
           

--- a/demo.jsx
+++ b/demo.jsx
@@ -64,6 +64,10 @@ class BraintreeHostedfieldDemo extends React.PureComponent {
             </div>
         );
     }
+  
+    onAuthorizationSuccess() {
+      this.numberField.focus();
+    }
 
     render() {
         return (
@@ -74,6 +78,7 @@ class BraintreeHostedfieldDemo extends React.PureComponent {
 
                 <Braintree
                     authorization={this.state.authorization}
+                    onAuthorizationSuccess={this.onAuthorizationSuccess}
                     onError={this.onError}
                     getTokenRef={t => (this.tokenize = t)}
                     onCardTypeChange={this.onCardTypeChange}
@@ -95,6 +100,7 @@ class BraintreeHostedfieldDemo extends React.PureComponent {
                             onBlur={() => this.setState({ numberFocused: false })}
                             onFocus={() => this.setState({ numberFocused: true })}
                             className={this.state.numberFocused ? 'focused' : ''}
+                            ref={numberField => { this.numberField = numberField; }} />
                         />
                         <p>Card type: {this.state.card}</p>
                         Date:

--- a/package.json
+++ b/package.json
@@ -46,9 +46,9 @@
     "eslint-plugin-react": "^7.4.0",
     "jest": "^20.0.4",
     "jest-cli": "^20.0.4",
+    "prop-types": "^15.6",
     "raf": "^3.4.0",
     "react": "^16.0.0",
-    "prop-types": "^15.6",
     "react-dom": "^16.0.0",
     "react-test-renderer": "^16.0.0",
     "rollup": "^0.47.6",
@@ -57,7 +57,7 @@
     "webpack-dev-server": "^2.7.1"
   },
   "dependencies": {
-    "braintree-web": "^3.22"
+    "braintree-web": "^3.26.0"
   },
   "jest": {
     "setupFiles": [

--- a/src/api.js
+++ b/src/api.js
@@ -106,13 +106,13 @@ export default class BraintreeClientApi {
     clearField(fieldType, cb) {
         this.hostedFields.clear(fieldType, cb);
     }
-  
+
     setAttribute(fieldType, name, value) {
-      this.hostedFields.setAttribute({
-        field: fieldType,
-        attribute: name,
-        value: value
-      });
+        this.hostedFields.setAttribute({
+            field: fieldType,
+            attribute: name,
+            value,
+        });
     }
 
     onFieldEvent(eventName, event) {

--- a/src/api.js
+++ b/src/api.js
@@ -106,6 +106,14 @@ export default class BraintreeClientApi {
     clearField(fieldType, cb) {
         this.hostedFields.clear(fieldType, cb);
     }
+  
+    setAttribute(fieldType, name, value) {
+      this.hostedFields.setAttribute({
+        field: fieldType,
+        attribute: name,
+        value: value
+      });
+    }
 
     onFieldEvent(eventName, event) {
         const fieldHandlers = this.fieldHandlers[event.emittedBy];

--- a/src/braintree.jsx
+++ b/src/braintree.jsx
@@ -6,7 +6,7 @@ export default class Braintree extends React.Component {
 
     static propTypes = {
         children: PropTypes.node.isRequired,
-        onAuthorizationSuccess : PropTypes.func,
+        onAuthorizationSuccess: PropTypes.func,
         authorization: PropTypes.string,
         getTokenRef: PropTypes.func,
         onValidityChange: PropTypes.func,

--- a/src/field.jsx
+++ b/src/field.jsx
@@ -29,6 +29,10 @@ export default class BraintreeHostedField extends React.Component {
     clear() {
         this.context.braintreeApi.clearField(this.props.type);
     }
+  
+    setPlaceholder(text) {
+      this.context.braintreeApi.setAttribute(this.props.type, 'placeholder', text);
+    }
 
     componentWillMount() {
         this.fieldId = this.context.braintreeApi.checkInField(this.props);


### PR DESCRIPTION
- Added new `setAttribute` method to braintree's api
- Initialized `cvv` field with 'CVV' text as placeholder 
- Every time the credit card type changes, the placeholder text of `cvv` field will be updated with the stands for the new card type.
- Set the focus on the `number` field right after the form is authorized
- Upgrade `braintree-web` to 3.26.0 version