### PR TITLE
Add support for rejectUnsupportedCards

### DIFF
--- a/src/api.js
+++ b/src/api.js
@@ -85,7 +85,15 @@ export default class BraintreeClientApi {
     }
 
     checkInField({
-        formatInput, maxlength, minlength, placeholder, select, type, prefill, ...handlers
+        formatInput,
+        maxlength,
+        minlength,
+        placeholder,
+        select,
+        type,
+        prefill,
+        rejectUnsupportedCards,
+        ...handlers
     }) {
         const id = `field-wrapper-${this.nextFieldId()}`;
         this.fieldHandlers[type] = handlers;
@@ -98,6 +106,9 @@ export default class BraintreeClientApi {
             prefill,
             selector: `#${id}`,
         };
+        if (('number' === type) && rejectUnsupportedCards) {
+            this.fields.number.rejectUnsupportedCards = true;
+        }
         return id;
     }
 


### PR DESCRIPTION
Could we add support for `rejectUnsupportedCards` released in braintree-web 3.32.0 https://github.com/braintree/braintree-web/blob/master/CHANGELOG.md#3320?

This PR adds support for a prop on the card number hosted field:
`<HostedField type="number" rejectUnsupportedCards />`